### PR TITLE
fix: add -f to force delete out-of-date images

### DIFF
--- a/src/install.sh
+++ b/src/install.sh
@@ -174,7 +174,7 @@ set_edge_site_config(){
 
 clean_garbage_images(){
   if [[ ${clean_garbage_images} == true ]] ;then
-    docker images | grep none | awk '{print $3}' | xargs -I{} docker rmi {}
+    docker images | grep none | awk '{print $3}' | xargs -I{} docker rmi -f {}
   fi
 }
 


### PR DESCRIPTION
without -f, the images which retagged couldn't be removed.