### PR TITLE
fix: the link to the zh_CN version in <v2x_developer_guide.md>

### DIFF
--- a/docs/v2x_developer_guide.md
+++ b/docs/v2x_developer_guide.md
@@ -1,6 +1,6 @@
 # Developer Guide
 
-English | [简体中文](/src/v2x_developer_guide-zh_CN.md)
+English | [简体中文](./v2x_developer_guide-zh_CN.md)
 
 **Refer to technical blog: [OpenV2X development on hands](https://openv2x.org/posts/2022-08-27-1/)**
 


### PR DESCRIPTION
fix bug:

This bug can cause a  error of zh-CN file not found.